### PR TITLE
Add cf-app-template to homepage, Conductor scripts, Hugo front-matter fix

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "git submodule update --init --recursive",
+    "run": "hugo server --bind 127.0.0.1 --port \"${CONDUCTOR_PORT:-1313}\" --buildDrafts"
+  }
+}

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,6 +1,5 @@
 ---
 title: brittcrawford.com
-path: /
 ---
 
 These are things that I have built simply because I wanted them to exist, or in the case of **avro-sqlite**, because I wanted to see if I could.[^2] I like tools that serve me, not ones that try to extract value from me or my attention. I also like the [process of building and understanding](https://brucesterling.tumblr.com/post/749569601319452672/realistic-utopias-a-speech-by-bruce-sterling) the things that I use.
@@ -14,6 +13,7 @@ These are things that I have built simply because I wanted them to exist, or in 
 * [LLPM](https://github.com/britt/llpm) - Imagine Claude Code was a PM. 
 * [Teleprompter](https://github.com/britt/teleprompter)  - A system to manage and update prompts for LLMs at runtime on Cloudflare Workers.
 * [avro-sqlite](https://github.com/britt/avro-sqlite) - a Go package to read a SQLite database, extract the schema and data to [Apache Avro](https://avro.apache.org/) and vice versa
+* [cf-app-template](https://github.com/britt/cf-app-template) - A template for building Next.js apps on Cloudflare Workers, with boilerplate and deployment already wired up.
 * [yts](https://github.com/britt/vibes/tree/main/yts) - A bash function to download YouTube video transcripts and convert them to Markdown format.
 Following the example of [David Gasquez's](https://davidgasquez.com/useful-llm-tools-2024/) excellent [qv](https://github.com/davidgasquez/dotfiles/blob/bb9df4a369dbaef95ca0c35642de491c7dd41269/shell/zshrc#L75-L99) function.
 

--- a/content/cocktails/_index.md
+++ b/content/cocktails/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Cocktail Recipes
-path: /cocktails
 ---
 
 A small but growing collection of cocktails that I have created. <del>I use [Highball](http://www.studioneat.com/products/highball) on my phone to keep track of the recipes. I have no connection to [Studio Neat](http://www.studioneat.com/) who makes it. It's just a nice app. You should check it out.</del> 

--- a/content/cocktails/anderson-island-sunset/index.md
+++ b/content/cocktails/anderson-island-sunset/index.md
@@ -1,7 +1,6 @@
 ---
 title: Anderson Island Sunset
 date: 2022-07-14
-path: /cocktails/anderson-island-sunset/
 ---
 
 This cocktail was born from the age old question, "What do we have?". I was staying at a cabin on Anderson island with family. A lot of were packed in. I was sleeping in my van, and there were tents set up in the yard. My sister Katie, my cousins Jon and Alyssa, and I foraged through the kitchen and created a cocktail to commermorate the occasion, and get us ready to go to the concert of a *13 piece Huey Lewis cover band who's name I cant remember* 🤷‍♂️

--- a/content/cocktails/bitter-nonsense/index.md
+++ b/content/cocktails/bitter-nonsense/index.md
@@ -1,7 +1,6 @@
 ---
 title: Bitter Nonsense
 date: 2024-12-11
-path: /cocktails/bitter-nonsense/
 ---
 
 A Negroni's neurotic cousin who moved to the suburbs, got a soda maker, and now won't shut up about "balance" while still being fundamentally unhinged.

--- a/content/cocktails/bittersweet-symphony/index.md
+++ b/content/cocktails/bittersweet-symphony/index.md
@@ -1,7 +1,6 @@
 ---
 title: Bittersweet Symphony
 date: 2025-04-28
-path: /cocktails/bittersweet-symphony/
 ---
 
 A bourbon Paloma that swapped grapefruit soda for fresh juice much to its benefit.

--- a/content/cocktails/el-nino/index.md
+++ b/content/cocktails/el-nino/index.md
@@ -1,7 +1,6 @@
 ---
 title: El Niño
 date: 2014-04-01
-path: /cocktails/el-nino/
 ---
 
 This is the one cocktail in the collection that I didn't create. My friend [Josh Kelly](https://twitter.com/jcoltkelly) devised this recipe, and on a trip to the beach after many iterations we pronounced it good. 

--- a/content/cocktails/envejeciendo/index.md
+++ b/content/cocktails/envejeciendo/index.md
@@ -1,7 +1,6 @@
 ---
 title: Envejeciendo
 date: 2025-07-17
-path: /cocktails/envejeciendo/
 ---
 
 When I was young I thought only old people like grapefruit. Then I started to like it and decided I was old. This combines grapefruit, Mezcal, and bit of spice. It's delightful to drink while watching [Slow Horses](https://www.rottentomatoes.com/tv/slow_horses).

--- a/content/cocktails/holiday-spiced-sour/index.md
+++ b/content/cocktails/holiday-spiced-sour/index.md
@@ -1,7 +1,6 @@
 ---
 title: Holiday Spiced Sour
 date: 2024-12-25
-path: /cocktails/holiday-spiced-sour/
 ---
 
 A whiskey sour that raided the spice cabinet at Christmas.

--- a/content/cocktails/johnny-appleseed/index.md
+++ b/content/cocktails/johnny-appleseed/index.md
@@ -1,7 +1,6 @@
 ---
 title: Johnny Appleseed
 date: 2014-04-01
-path: /cocktails/johnny-appleseed/
 ---
 
 An variant of the [Rattlesnake]() using Apple Jack instead of Rye. 

--- a/content/cocktails/la-pomme-forte/index.md
+++ b/content/cocktails/la-pomme-forte/index.md
@@ -1,7 +1,6 @@
 ---
 title: La Pomme Forte
 date: 2014-04-01
-path: /cocktails/la-pomme-forte/
 ---
 
 A refreshing and delicious Apple Jack cocktail named in bad French. 

--- a/content/cocktails/mother-of-invention/index.md
+++ b/content/cocktails/mother-of-invention/index.md
@@ -1,7 +1,6 @@
 ---
 title: Mother of Invention
 date: 2024-11-23
-path: /cocktails/mother-of-invention/
 ---
 
 The name says it all. It was made with what I had at the time.

--- a/content/cocktails/protein-g1/index.md
+++ b/content/cocktails/protein-g1/index.md
@@ -1,7 +1,6 @@
 ---
 title: Protein G1
 date: 2024-02-09
-path: /cocktails/protein-g1/
 ---
 
 A healthy liquid breakfast. 

--- a/content/cocktails/slightly-sour-strawberry-smash/index.md
+++ b/content/cocktails/slightly-sour-strawberry-smash/index.md
@@ -1,7 +1,6 @@
 ---
 title: Slightly Sour Strawberry Smash
 date: 2017-03-16
-path: /cocktails/slightly-sour-strawberry-smash/
 ---
 
 A strawberry old fashioned with a sweet and sour taste. The walnut cordial is somewhat sour and balances the sweetness and fruitiness of the strawberry much like balsamic vinegar in a strawberry salad. Sounds weird. Tastes great. 

--- a/content/cocktails/thats-just-dandy/index.md
+++ b/content/cocktails/thats-just-dandy/index.md
@@ -1,7 +1,6 @@
 ---
 title: That's Just Dandy
 date: 2017-08-15
-path: /cocktails/thats-just-dandy/
 ---
 
 Named after the first words to come out of my mouth after tasting it. We bought tons of apricots this Summer and now have tons of apricot jam, and I was searching for something to do with it. 

--- a/content/cocktails/yippee-kay-yay-motherfucker/index.md
+++ b/content/cocktails/yippee-kay-yay-motherfucker/index.md
@@ -1,7 +1,6 @@
 ---
 title: Yippee Kay Yay Motherfucker!
 date: 2014-03-19
-path: /cocktails/yippee-kay-yay-motherfucker/
 ---
 
 A spicy variant on the Old Fashioned, a tribute to [John McClane](https://en.wikipedia.org/wiki/John_McClane) and a terrible pun. 

--- a/content/daresnot/index.md
+++ b/content/daresnot/index.md
@@ -1,7 +1,6 @@
 ---
 title: Daresnot
 date: 2018-03-08
-path: /daresnot/
 ---
 
 ## electronic voting with time limited privacy

--- a/content/projects.md
+++ b/content/projects.md
@@ -1,6 +1,5 @@
 ---
 title: Projects
-path: /projects
 ---
 
 ## Home Cooked Software [^1]


### PR DESCRIPTION
Adds [cf-app-template](https://github.com/britt/cf-app-template) to the Home Cooked Software list on the homepage. Also adds a `conductor.json` with a setup script (theme submodule init) and a run script that starts the Hugo dev server on Conductor's assigned port. Finally, removes the deprecated `path` front-matter key (removed in Hugo v0.144) from 17 content files — it was breaking the local dev server with current Hugo, and all values matched the natural URLs so nothing changes on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)